### PR TITLE
Add @JsonIgnore

### DIFF
--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
@@ -17,6 +17,10 @@ import javax.persistence.Table
 @Entity
 @Table(name = "threads")
 data class BbsThread(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    var id: Long = 0,
     @Column(name = "title", nullable = false)
     var title: String,
     @Column(name = "description", nullable = false)
@@ -34,20 +38,16 @@ data class BbsThread(
     var createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(name = "updated_at", nullable = false)
     @JsonIgnore
-    var updatedAt: LocalDateTime = LocalDateTime.now(),
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    var id: Long = 0
+    var updatedAt: LocalDateTime = LocalDateTime.now()
 ) : Serializable {
     constructor(
         request: ThreadRegistrationRequest,
         category: Category,
         author: User
     ) : this(
-        request.title,
-        request.description,
-        category,
-        author
+        title = request.title,
+        description = request.description,
+        category = category,
+        author = author
     )
 }

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
@@ -1,5 +1,7 @@
 package com.u1fukui.bbsapi.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.u1fukui.bbsapi.request.ThreadRegistrationRequest
 import java.io.Serializable
 import java.time.LocalDateTime
@@ -21,6 +23,7 @@ data class BbsThread(
     var description: String,
     @ManyToOne
     @JoinColumn(name = "category_id", nullable = false)
+    @JsonIgnoreProperties("threads")
     var category: Category,
     @ManyToOne
     @JoinColumn(name = "author_id", nullable = false)
@@ -30,6 +33,7 @@ data class BbsThread(
     @Column(name = "created_at", nullable = false)
     var createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(name = "updated_at", nullable = false)
+    @JsonIgnore
     var updatedAt: LocalDateTime = LocalDateTime.now(),
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/Category.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/Category.kt
@@ -15,6 +15,10 @@ import javax.persistence.Table
 @Entity
 @Table(name = "categories")
 data class Category(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    var id: Long = 0,
     @Column(name = "name", nullable = false)
     var name: String = "",
     @Column(name = "order_num", nullable = false)
@@ -29,13 +33,10 @@ data class Category(
     @Column(name = "updated_at", nullable = false)
     @JsonIgnore
     var updatedAt: LocalDateTime = LocalDateTime.now(),
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    var id: Long = 0,
     @OneToMany(mappedBy = "category")
     @JsonIgnoreProperties("category")
     var threads: List<BbsThread> = emptyList()
 ) : Serializable {
+
     constructor(categoryId: Long) : this(id = categoryId)
 }

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/Category.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/Category.kt
@@ -1,5 +1,6 @@
 package com.u1fukui.bbsapi.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.io.Serializable
 import java.time.LocalDateTime
@@ -17,12 +18,16 @@ data class Category(
     @Column(name = "name", nullable = false)
     var name: String = "",
     @Column(name = "order_num", nullable = false)
+    @JsonIgnore
     var order: Int = 0,
     @Column(name = "disabled", nullable = false)
-    var isDisabled: Boolean = false,
+    @JsonIgnore
+    var disabled: Boolean = false,
     @Column(name = "created_at", nullable = false)
+    @JsonIgnore
     var createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(name = "updated_at", nullable = false)
+    @JsonIgnore
     var updatedAt: LocalDateTime = LocalDateTime.now(),
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/User.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/User.kt
@@ -14,6 +14,10 @@ import javax.persistence.Table
 @Entity
 @Table(name = "users")
 data class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    var id: Long = 0,
     @Column(name = "name", nullable = false)
     var name: String,
     @Column(name = "created_at", nullable = false)
@@ -21,11 +25,7 @@ data class User(
     var createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(name = "updated_at", nullable = false)
     @JsonIgnore
-    var updatedAt: LocalDateTime = LocalDateTime.now(),
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    var id: Long = 0
+    var updatedAt: LocalDateTime = LocalDateTime.now()
 ) : Serializable {
-    constructor(request: UserRegistrationRequest) : this(request.name)
+    constructor(request: UserRegistrationRequest) : this(name = request.name)
 }

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/User.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/User.kt
@@ -1,5 +1,6 @@
 package com.u1fukui.bbsapi.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.u1fukui.bbsapi.request.UserRegistrationRequest
 import java.io.Serializable
 import java.time.LocalDateTime
@@ -16,8 +17,10 @@ data class User(
     @Column(name = "name", nullable = false)
     var name: String,
     @Column(name = "created_at", nullable = false)
+    @JsonIgnore
     var createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(name = "updated_at", nullable = false)
+    @JsonIgnore
     var updatedAt: LocalDateTime = LocalDateTime.now(),
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## やったこと
- API レスポンスの JSON に不要なプロパティが含まれていたので、クライアントに返す必要ないものに @JsonIgonore を付けた
- API レスポンスの JSON のプロパティ順が、Entity クラスに宣言した順番と同じになる事が分かったので、id を先頭にした