### PR TITLE
Use entityManager to paging of thread list

### DIFF
--- a/src/main/kotlin/com/u1fukui/bbsapi/controller/ThreadController.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/controller/ThreadController.kt
@@ -3,7 +3,6 @@ package com.u1fukui.bbsapi.controller
 import com.u1fukui.bbsapi.entity.BbsThread
 import com.u1fukui.bbsapi.entity.Category
 import com.u1fukui.bbsapi.request.ThreadRegistrationRequest
-import com.u1fukui.bbsapi.service.CategoryService
 import com.u1fukui.bbsapi.service.ThreadService
 import com.u1fukui.bbsapi.service.UserService
 import org.springframework.http.ResponseEntity
@@ -16,8 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class ThreadController(
     private val userService: UserService,
-    private val threadService: ThreadService,
-    private val categoryService: CategoryService
+    private val threadService: ThreadService
 ) {
     @PostMapping("/thread/register")
     fun registerThread(@RequestBody request: ThreadRegistrationRequest): ResponseEntity<String> {
@@ -33,11 +31,9 @@ class ThreadController(
     @GetMapping("/threads")
     fun getThreadList(
         @RequestParam(value = "category") categoryId: Long,
-        @RequestParam(value = "lastId", defaultValue = "0") lastId: Int
+        @RequestParam(value = "lastId", defaultValue = "0") lastId: Long
     ): ResponseEntity<List<BbsThread>> {
-        val category = categoryService.findById(categoryId)
-                ?: return ResponseEntity.badRequest().build()
-
-        return ResponseEntity.ok(category.threads)
+        val list = threadService.findByCategoryId(categoryId, lastId)
+        return ResponseEntity.ok(list)
     }
 }

--- a/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/entity/BbsThread.kt
@@ -3,6 +3,7 @@ package com.u1fukui.bbsapi.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.u1fukui.bbsapi.request.ThreadRegistrationRequest
+import org.hibernate.annotations.NamedQuery
 import java.io.Serializable
 import java.time.LocalDateTime
 import javax.persistence.Column
@@ -16,6 +17,8 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "threads")
+@NamedQuery(name = "findByCategoryId",
+    query = "SELECT t FROM BbsThread t WHERE t.category.id = :categoryId AND t.id > :lastId ORDER BY t.id DESC")
 data class BbsThread(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/u1fukui/bbsapi/service/ThreadService.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/service/ThreadService.kt
@@ -4,4 +4,5 @@ import com.u1fukui.bbsapi.entity.BbsThread
 
 interface ThreadService {
     fun register(thread: BbsThread)
+    fun findByCategoryId(categoryId: Long, lastId: Long): List<BbsThread>
 }

--- a/src/main/kotlin/com/u1fukui/bbsapi/service/impl/ThreadServiceImpl.kt
+++ b/src/main/kotlin/com/u1fukui/bbsapi/service/impl/ThreadServiceImpl.kt
@@ -3,15 +3,28 @@ package com.u1fukui.bbsapi.service.impl
 import com.u1fukui.bbsapi.entity.BbsThread
 import com.u1fukui.bbsapi.repository.ThreadRepository
 import com.u1fukui.bbsapi.service.ThreadService
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import javax.persistence.EntityManager
 
 @Service
 class ThreadServiceImpl(
     private val repository: ThreadRepository
 ) : ThreadService {
+    @Autowired
+    lateinit var entityManager: EntityManager
+
     @Transactional(timeout = 10)
     override fun register(thread: BbsThread) {
         repository.save(thread)
     }
+
+    @Transactional(timeout = 10)
+    override fun findByCategoryId(categoryId: Long, lastId: Long): List<BbsThread> =
+        entityManager.createNamedQuery("findByCategoryId", BbsThread::class.java)
+            .setParameter("categoryId", categoryId)
+            .setParameter("lastId", lastId)
+            .setMaxResults(20)
+            .resultList
 }


### PR DESCRIPTION
スレッドリストを取得する API にページング機能を実装した。

## やったこと
- はじめは `Pageable` を利用しようと思ったが、`lastId` を指定するやり方ではなく、ページの offset を指定する事しか出来なかった
  - そのやり方だと、最初のページから次のページを取得するまでの間に、新しくスレッドが投稿されたりするとリストに重複が発生しそうだったので避けたかった
- 仕方ないので、`EntityManager` + `@NamedQuery` を利用するやり方を採用した
  - `@NamedQuery` に指定するのは、テーブル名ではなくてモデル名の必要があるので注意